### PR TITLE
Automatically deploy release binaries from Travis

### DIFF
--- a/.ci/if_deploy_build.sh
+++ b/.ci/if_deploy_build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-if [ "$TRAVIS_RUST_VERSION" = "1.35.0" ]; then
+if [ "$TRAVIS_RUST_VERSION" = "1.35.0" -a -n "$TRAVIS_TAG" ]; then
     "$@"
 fi

--- a/.ci/if_deploy_build.sh
+++ b/.ci/if_deploy_build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if [ "$TRAVIS_RUST_VERSION" = "1.35.0" ]; then
+    "$@"
+fi

--- a/.ci/package.sh
+++ b/.ci/package.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-readonly pkgver="$(git tag -l --points-at HEAD | grep '^v.*$' | sed -n 's/^v//p')"
+if [ -z "$TRAVIS_TAG" ]; then
+    readonly pkgver="$TRAVIS_BRANCH"
+else
+    if [[ "$TRAVIS_TAG" =~ ^v.*$ ]]; then
+        readonly pkgver="$(echo $TRAVIS_TAG | sed -n 's/^v//p')"
+    else
+        readonly pkgver="$TRAVIS_TAG"
+    fi
+fi
 
 if [ -z "$1" ]; then
     readonly release_dir="target/release"

--- a/.ci/package.sh
+++ b/.ci/package.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+readonly pkgver="$(git tag -l --points-at HEAD | grep '^v.*$' | sed -n 's/^v//p')"
+
+if [ -z "$1" ]; then
+    readonly release_dir="target/release"
+    readonly tar_suffix=""
+else
+    readonly release_dir="target/$1/release"
+    readonly tar_suffix="-$1"
+fi
+
+tar -czf "bender-$pkgver-x86_64-linux-gnu$tar_suffix.tar.gz" \
+        -C "./$release_dir" \
+        --owner=0 --group=0 \
+        bender

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!/.ci/
 !.git*
 !.travis.yml
 /target

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: rust
 rust:
-  - stable
-  - beta
+  #- stable
+  - "1.35.0"
+  #- beta
   - nightly
   # minimum supported version
   - "1.31.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,42 @@ matrix:
   allow_failures:
     - rust: nightly
 
+services:
+  - docker
+
+before_install:
+  - for centos in '7.4.1708' '7.6.1810'; do
+      .ci/if_deploy_build.sh docker pull accuminium/rust-centos:${centos}_${TRAVIS_RUST_VERSION};
+    done
+
 script:
   - cargo build
   - cargo test --all
   - tests/run_all.sh
+
+after_success:
+  - .ci/if_deploy_build.sh cargo build --release
+  - for centos in '7.4.1708' '7.6.1810'; do
+      .ci/if_deploy_build.sh docker run
+        -t --rm
+        -v "$PWD:/source"
+        -v "$PWD/target/centos$centos:/source/target"
+        accuminium/rust-centos:${centos}_${TRAVIS_RUST_VERSION}
+        cargo build --release;
+    done
+
+before_deploy:
+  - .ci/if_deploy_build.sh .ci/package.sh
+  - for centos in '7.4.1708' '7.6.1810'; do
+      .ci/if_deploy_build.sh .ci/package.sh centos$centos;
+    done
+
+deploy:
+  provider: releases
+  api_key:
+    secure: Et/yWVnSVDk9gwCQbxt/VmTQ+qrdlRfgsQUD1bwOB5N4LDZYFPpWqtzfPeVc7FYXoE7cMNNb/NqwVszV38fd8yWB1uqzerCxduH7eQK4GAwJk64+aLFxuXyVZlocHMdY7ew+/kgftFahrzZMfslR83S82zR4JHVOuAUpRL06+2Zix7DoSS+MLJROCqsITJkofKQm6o47/SuhJdAVXSBTfkE7GdOVq0qcu8sUkIj93b+Z8TB3XGUb6/dlG4hZYoeS+ocjGChWTHDONuq0V7TmBeGN4hJRrDkJneuAGMTF4mIpzO/Iscm791atcj1o+VoNOm9BbY1Oi9vWEeL3Io38YbwiceumZkxlBHtdt9U0GDrn3iMO8MIcxF7F1GP6HqudVKn3TvNhDk2Kuf8AFI1LTLaPgB26ehtw2912F18CsytdUGGC+p4eZ+s+y/8+PxhiLPTRXQkcy8zyxclFC4oaodJ97/zTtHDH/PpZ0/nCeC35PXT4VI1VTZGOVjOF7kANBTAecUu6zqKOvydTRgYPGAydf6JHpAG7S+GnyIJpQ91uvn2vaqxdHfbdqKSokAD2H2xLDaeJZVH+WxtyWV3BA3o47JHnuhk0x3XkptAmUw1AHz6f4SmjkU9rODd/cP8ICUd4NnUXp/arksWMx4NrysbzKNRet1EyIDMNgclShrc=
+  file_glob: true
+  file: bender-*.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
With this patch, Travis build release binaries for Linux and two recent CentOS versions (to precisely match the target libc) for every tag and attaches them as asset to a release on GitHub, see [this example](https://github.com/fabianschuiki/bender/releases/tag/ci-test).