### PR TITLE
script: Define format-specific targets even if no target is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 ### Fixed
 - Fix rustc 1.36 `as_ref` [regression](https://github.com/rust-lang/rust/issues/60958)
+- Emit format-specific target defines even if no target is specified.
 
 ## 0.13.2 - 2019-07-29
 ### Fixed

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -63,7 +63,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let targets = matches
         .values_of("target")
         .map(|t| TargetSet::new(t.chain(format_targets.into_iter().cloned())))
-        .unwrap_or_else(|| TargetSet::empty());
+        .unwrap_or_else(|| TargetSet::new(format_targets.into_iter()));
     let srcs = srcs
         .filter_targets(&targets)
         .unwrap_or_else(|| SourceGroup {


### PR DESCRIPTION
Emit format-specific target defines even if no target is specified.

Previously, `bender script <format>` would emit target-specific (e.g., `'TARGET_SYNTHESIS`) `define`s only if `-t <some target>` was additionally specified.