### PR TITLE
Add `script vivado`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `vivado` format to the `script` command.
 
 ## 0.13.3 - 2019-07-29
 ### Changed


### PR DESCRIPTION
This adds an initial implementation for `bender script vivado`, which outputs commands to add all source files, set all include directories for all files, and set all defines for all files.

This is a very coarse-grained method, but in Vivado the only way to set include directories and defines on a *subset* of files would be to define multiple filesets, which leads to out-of-context synthesis in Vivado, which is not always desirable. We may later add an option to `script vivado` that allows to do this.

I validated the resulting commands in Vivado 2018.3.