### PR TITLE
script: Add `--abort-on-error` flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 script:
   - cargo build
   - cargo test --all
-  - cargo fmt -- --check
+  - "[ $TRAVIS_RUST_VERSION != stable ] || cargo fmt -- --check"
   - tests/run_all.sh
 
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 ### Added
 - Add `flist` scripts target emitting a plain file list.
+### Changed
+- Add `--abort-on-error` flag to the `script` command (effective for `synopsys` and `vsim`).
 
 ## 0.18.0 - 2020-04-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 - Add `flist` scripts target emitting a plain file list.
 ### Changed
-- Add `--abort-on-error` flag to the `script` command (effective for `synopsys` and `vsim`).
+- `script` now inserts Tcl `catch` statements for `synopsys` and `vsim` to abort elaboration on the first error.  This can be disabled with the new `--no-abort-on-error` flag.
 
 ## 0.18.0 - 2020-04-03
 ### Added

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -99,9 +99,9 @@ pub fn new<'a, 'b>() -> App<'a, 'b> {
                 .number_of_values(1),
         )
         .arg(
-            Arg::with_name("abort-on-error")
-                .long("abort-on-error")
-                .help("Abort analysis/compilation on first caught error")
+            Arg::with_name("no-abort-on-error")
+                .long("no-abort-on-error")
+                .help("Do not abort analysis/compilation on first caught error (only for programs that support early aborting)")
         )
 }
 
@@ -129,7 +129,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
         _ => unreachable!(),
     };
 
-    let abort_on_error = matches.is_present("abort-on-error");
+    let abort_on_error = !matches.is_present("no-abort-on-error");
 
     // Filter the sources by target.
     let targets = matches

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -579,10 +579,23 @@ fn emit_synopsys_tcl(
             },
             |src, ty, files| {
                 let mut lines = vec![];
-                lines.push(tcl_catch_prefix(&format!("analyze -format {}", match ty {
-                        SourceType::Verilog => { "sv" }
-                        SourceType::Vhdl => { "vhdl" }
-                    }), abort_on_error).to_owned());
+                lines.push(
+                    tcl_catch_prefix(
+                        &format!(
+                            "analyze -format {}",
+                            match ty {
+                                SourceType::Verilog => {
+                                    "sv"
+                                }
+                                SourceType::Vhdl => {
+                                    "vhdl"
+                                }
+                            }
+                        ),
+                        abort_on_error,
+                    )
+                    .to_owned(),
+                );
 
                 // Add defines.
                 let mut defines: Vec<(String, Option<&str>)> = vec![];

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -558,14 +558,10 @@ fn emit_synopsys_tcl(
             },
             |src, ty, files| {
                 let mut lines = vec![];
-                match ty {
-                    SourceType::Verilog => {
-                        lines.push("analyze -format sv".to_owned());
-                    }
-                    SourceType::Vhdl => {
-                        lines.push("analyze -format vhdl".to_owned());
-                    }
-                }
+                lines.push(format!("analyze -format {}", match ty {
+                        SourceType::Verilog => { "sv" }
+                        SourceType::Vhdl => { "vhdl" }
+                    }).to_owned());
 
                 // Add defines.
                 let mut defines: Vec<(String, Option<&str>)> = vec![];


### PR DESCRIPTION
This flag causes compilation/analysis scripts to abort on errors that can be caught with Tcl's `catch`.