### PR TITLE
Add repository information to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bender"
 version = "0.13.3"
 authors = ["Fabian Schuiki <fschuiki@iis.ee.ethz.ch>", "Andreas Kurth <akurth@iis.ee.ethz.ch>"]
+repository = "https://github.com/fabianschuiki/bender"
 description = "A dependency management tool for hardware projects."
 readme = "README.md"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
I found this project through crates.io. But there is not link to this repository.
I think the link is useful.