### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/src.rs
+++ b/src/src.rs
@@ -135,7 +135,7 @@ impl<'ctx> SourceGroup<'ctx> {
                     grp.independent &= self.independent;
                     grp.target = TargetSpec::All(
                         [&self.target, &grp.target]
-                            .into_iter()
+                            .iter()
                             .map(|&i| i.clone())
                             .collect(),
                     );


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.