### PR TITLE
Add support for VCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `vcs` format to the `script` command.
+
+### Changed
+- `script`: `vcom-arg` or `vlog-arg` can be used with format `vsim` or `vcs`.
 
 ## 0.15.0 - 2020-02-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Targets are flags that can be used to filter source files and dependencies. They
 
 - **Tool**: You should set exactly one of the following to indicate with which tool you are working.
 
-  - `vsim`: Set this target when working with Siemens vsim. Automatically set by the *bender-vsim* plugin.
+  - `vsim`: Set this target when working with ModelSim vsim. Automatically set by the *bender-vsim* plugin.
+
+  - `vcs`: Set this target when working with Synopsys VCS. Automatically set by the *bender-vcs* plugin.
 
   - `synopsys`: Set this target when working with Synopsys Design Compiler. Automatically set by the *bender-synopsys* plugin.
 

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -93,7 +93,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     // Format-specific target specifiers.
     let format_targets: &[&str] = match matches.value_of("format").unwrap() {
         "vsim" => &["vsim", "simulation"],
-        "vcs" => &["vca", "simulation"],
+        "vcs" => &["vcs", "simulation"],
         "synopsys" => &["synopsys", "synthesis"],
         "vivado" => &["vivado", "synthesis", "fpga", "xilinx"],
         _ => unreachable!(),
@@ -121,7 +121,7 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     // Validate format-specific options.
     if (matches.is_present("vcom-arg") || matches.is_present("vlog-arg"))
             && matches.value_of("format") != Some("vsim") && matches.value_of("format") != Some("vcs") {
-        return Err(Error::new("vsim/vcs-only options can only be used for 'vsim/vcs' format!"));
+        return Err(Error::new("vsim/vcs-only options can only be used for 'vcs' or 'vsim' format!"));
     }
     if (matches.is_present("only-defines") || matches.is_present("only-includes")
                 || matches.is_present("only-sources") || matches.is_present("no-simset")


### PR DESCRIPTION
Adds a `vcs` format to create the compilation script for Synopsys VCS.
Additionally, it adds two options that can only be used with VCS:
- `--vlogan-bin` to specify the binary for analyzing Verilog files
- `--vhdlan-bin` to specify the binary for analyzing VHDL files

TODO:
- [x]  Test Verilog commands
- [ ]  Test VHDL commands
- [ ] CI?