### PR TITLE
Improve `script`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- `script vcs`: Fix shell syntax to define `ROOT` variable.
 
 ## 0.16.0 - 2020-02-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- `script vivado` now emits paths relative to the project root with the `ROOT` variable.
+
 ### Fixed
 - `script vcs`: Fix shell syntax to define `ROOT` variable.
 

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -274,7 +274,7 @@ fn emit_vcs_sh(
 ) -> Result<()> {
     println!("#!/usr/bin/env bash");
     println!("# This script was generated automatically by bender.");
-    println!("set ROOT \"{}\"", sess.root.to_str().unwrap());
+    println!("set ROOT {}", quote(sess.root.to_str().unwrap()));
     for src in srcs {
         separate_files_in_group(
             src,
@@ -313,14 +313,9 @@ fn emit_vcs_sh(
                             lines.push(s);
                         }
                         for i in &src.include_dirs {
-                            if i.starts_with(sess.root) {
-                                lines.push(format!(
-                                    "\"+incdir+$ROOT/{}\"",
-                                    i.strip_prefix(sess.root).unwrap().to_str().unwrap()
-                                ));
-                            } else {
-                                lines.push(format!("\"+incdir+{}\"", i.to_str().unwrap()));
-                            }
+                            lines.push(quote(&format!(
+                                "+incdir+{}", relativize_path(i, sess.root)
+                            )));
                         }
                     }
                     SourceType::Vhdl => {
@@ -335,14 +330,7 @@ fn emit_vcs_sh(
                         SourceFile::File(p) => p,
                         _ => continue,
                     };
-                    if p.starts_with(sess.root) {
-                        lines.push(format!(
-                            "\"$ROOT/{}\"",
-                            p.strip_prefix(sess.root).unwrap().to_str().unwrap()
-                        ));
-                    } else {
-                        lines.push(format!("\"{}\"", p.to_str().unwrap()));
-                    }
+                    lines.push(quote(&relativize_path(p, sess.root)));
                 }
                 println!("");
                 println!("{}", lines.join(" \\\n    "));

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -438,7 +438,7 @@ fn emit_synopsys_tcl(
 
 /// Emit a script to add sources to Vivado.
 fn emit_vivado_tcl(
-    _sess: &Session,
+    sess: &Session,
     matches: &ArgMatches,
     targets: TargetSet,
     srcs: Vec<SourceGroup>,
@@ -467,7 +467,7 @@ fn emit_vivado_tcl(
         }
     }
 
-    println!("# This script was generated automatically by bender.");
+    println!("{}", header_tcl(sess));
     let mut include_dirs = vec![];
     let mut defines = vec![];
     let filesets = if matches.is_present("no-simset") {
@@ -477,7 +477,7 @@ fn emit_vivado_tcl(
     };
     for src in srcs {
         for i in &src.include_dirs {
-            include_dirs.push(i.to_str().unwrap());
+            include_dirs.push(relativize_path(i, sess.root));
         }
         separate_files_in_group(
             src,
@@ -497,7 +497,7 @@ fn emit_vivado_tcl(
                         SourceFile::File(p) => p,
                         _ => continue,
                     };
-                    lines.push(format!("{}", p.to_str().unwrap()));
+                    lines.push(relativize_path(p, sess.root));
                 }
                 if output_components.sources {
                     println!("{} \\\n]", lines.join(" \\\n    "));

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -193,6 +193,15 @@ fn relativize_path(path: &std::path::Path, root: &std::path::Path) -> String {
     }
 }
 
+static HEADER_AUTOGEN: &str = "This script was generated automatically by bender.";
+
+fn header_tcl(sess: &Session) -> String {
+    let mut lines = vec![];
+    lines.push(format!("# {}", HEADER_AUTOGEN));
+    lines.push(format!("set ROOT {}", quote(sess.root.to_str().unwrap())));
+    lines.join("\n")
+}
+
 /// Emit a vsim compilation script.
 fn emit_vsim_tcl(
     sess: &Session,
@@ -200,8 +209,7 @@ fn emit_vsim_tcl(
     targets: TargetSet,
     srcs: Vec<SourceGroup>,
 ) -> Result<()> {
-    println!("# This script was generated automatically by bender.");
-    println!("set ROOT {}", quote(sess.root.to_str().unwrap()));
+    println!("{}", header_tcl(sess));
     for src in srcs {
         separate_files_in_group(
             src,
@@ -347,9 +355,8 @@ fn emit_synopsys_tcl(
     targets: TargetSet,
     srcs: Vec<SourceGroup>,
 ) -> Result<()> {
-    println!("# This script was generated automatically by bender.");
+    println!("{}", header_tcl(sess));
     println!("set search_path_initial $search_path");
-    println!("set ROOT {}", quote(sess.root.to_str().unwrap()));
     let relativize_path = |p: &std::path::Path| quote(&relativize_path(p, sess.root));
     for src in srcs {
         // Adjust the search path.

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -202,6 +202,14 @@ fn header_tcl(sess: &Session) -> String {
     lines.join("\n")
 }
 
+fn header_sh(sess: &Session) -> String {
+    let mut lines = vec![];
+    lines.push("#!/usr/bin/env bash".to_string());
+    lines.push(format!("# {}", HEADER_AUTOGEN));
+    lines.push(format!("ROOT={}", quote(sess.root.to_str().unwrap())));
+    lines.join("\n")
+}
+
 /// Emit a vsim compilation script.
 fn emit_vsim_tcl(
     sess: &Session,
@@ -280,9 +288,7 @@ fn emit_vcs_sh(
     targets: TargetSet,
     srcs: Vec<SourceGroup>,
 ) -> Result<()> {
-    println!("#!/usr/bin/env bash");
-    println!("# This script was generated automatically by bender.");
-    println!("ROOT={}", quote(sess.root.to_str().unwrap()));
+    println!("{}", header_sh(sess));
     for src in srcs {
         separate_files_in_group(
             src,

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -274,7 +274,7 @@ fn emit_vcs_sh(
 ) -> Result<()> {
     println!("#!/usr/bin/env bash");
     println!("# This script was generated automatically by bender.");
-    println!("set ROOT {}", quote(sess.root.to_str().unwrap()));
+    println!("ROOT={}", quote(sess.root.to_str().unwrap()));
     for src in srcs {
         separate_files_in_group(
             src,

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -181,6 +181,14 @@ enum SourceType {
     Vhdl,
 }
 
+fn relativize_path(path: &std::path::Path, root: &std::path::Path) -> String {
+    if path.starts_with(root) {
+        format!("\"$ROOT/{}\"", path.strip_prefix(root).unwrap().to_str().unwrap())
+    } else {
+        format!("\"{}\"", path.to_str().unwrap())
+    }
+}
+
 /// Emit a vsim compilation script.
 fn emit_vsim_tcl(
     sess: &Session,
@@ -362,16 +370,7 @@ fn emit_synopsys_tcl(
     println!("# This script was generated automatically by bender.");
     println!("set search_path_initial $search_path");
     println!("set ROOT \"{}\"", sess.root.to_str().unwrap());
-    let relativize_path = |p: &std::path::Path| {
-        if p.starts_with(sess.root) {
-            format!(
-                "\"$ROOT/{}\"",
-                p.strip_prefix(sess.root).unwrap().to_str().unwrap()
-            )
-        } else {
-            format!("\"{}\"", p.to_str().unwrap())
-        }
-    };
+    let relativize_path = |p: &std::path::Path| relativize_path(p, sess.root);
     for src in srcs {
         // Adjust the search path.
         println!("");

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -349,7 +349,7 @@ fn emit_synopsys_tcl(
 ) -> Result<()> {
     println!("# This script was generated automatically by bender.");
     println!("set search_path_initial $search_path");
-    println!("set ROOT \"{}\"", sess.root.to_str().unwrap());
+    println!("set ROOT {}", quote(sess.root.to_str().unwrap()));
     let relativize_path = |p: &std::path::Path| quote(&relativize_path(p, sess.root));
     for src in srcs {
         // Adjust the search path.

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -181,11 +181,15 @@ enum SourceType {
     Vhdl,
 }
 
+fn quote(s: &str) -> String {
+    format!("\"{}\"", s)
+}
+
 fn relativize_path(path: &std::path::Path, root: &std::path::Path) -> String {
     if path.starts_with(root) {
-        format!("\"$ROOT/{}\"", path.strip_prefix(root).unwrap().to_str().unwrap())
+        format!("$ROOT/{}", path.strip_prefix(root).unwrap().to_str().unwrap())
     } else {
-        format!("\"{}\"", path.to_str().unwrap())
+        path.to_str().unwrap().to_string()
     }
 }
 
@@ -370,7 +374,7 @@ fn emit_synopsys_tcl(
     println!("# This script was generated automatically by bender.");
     println!("set search_path_initial $search_path");
     println!("set ROOT \"{}\"", sess.root.to_str().unwrap());
-    let relativize_path = |p: &std::path::Path| relativize_path(p, sess.root);
+    let relativize_path = |p: &std::path::Path| quote(&relativize_path(p, sess.root));
     for src in srcs {
         // Adjust the search path.
         println!("");

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -181,7 +181,7 @@ enum SourceType {
     Vhdl,
 }
 
-fn quote(s: &str) -> String {
+fn quote(s: &(impl std::fmt::Display + ?Sized)) -> String {
     format!("\"{}\"", s)
 }
 

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -201,7 +201,7 @@ fn emit_vsim_tcl(
     srcs: Vec<SourceGroup>,
 ) -> Result<()> {
     println!("# This script was generated automatically by bender.");
-    println!("set ROOT \"{}\"", sess.root.to_str().unwrap());
+    println!("set ROOT {}", quote(sess.root.to_str().unwrap()));
     for src in srcs {
         separate_files_in_group(
             src,
@@ -238,14 +238,9 @@ fn emit_vsim_tcl(
                             lines.push(s);
                         }
                         for i in &src.include_dirs {
-                            if i.starts_with(sess.root) {
-                                lines.push(format!(
-                                    "\"+incdir+$ROOT/{}\"",
-                                    i.strip_prefix(sess.root).unwrap().to_str().unwrap()
-                                ));
-                            } else {
-                                lines.push(format!("\"+incdir+{}\"", i.to_str().unwrap()));
-                            }
+                            lines.push(quote(&format!(
+                                "+incdir+{}", relativize_path(i, sess.root)
+                            )));
                         }
                     }
                     SourceType::Vhdl => {
@@ -260,14 +255,7 @@ fn emit_vsim_tcl(
                         SourceFile::File(p) => p,
                         _ => continue,
                     };
-                    if p.starts_with(sess.root) {
-                        lines.push(format!(
-                            "\"$ROOT/{}\"",
-                            p.strip_prefix(sess.root).unwrap().to_str().unwrap()
-                        ));
-                    } else {
-                        lines.push(format!("\"{}\"", p.to_str().unwrap()));
-                    }
+                    lines.push(quote(&relativize_path(p, sess.root)));
                 }
                 println!("");
                 println!("{}", lines.join(" \\\n    "));


### PR DESCRIPTION
Closes #22.

### Changed
- `script vivado` now emits paths relative to the project root with the `ROOT` variable.

### Fixed
- `script vcs`: Fix shell syntax to define `ROOT` variable.