### PR TITLE
script: Add `vivado-sim` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `vivado-sim` format to the script command.  This format differs from the `vivado` format in that it targets simulation, not synthesis; other than that, it is equivalent to the `vivado` format.
 
 ## 0.16.1 - 2020-03-10
 ### Changed

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -91,7 +91,8 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
     let srcs = core.run(io.sources())?;
 
     // Format-specific target specifiers.
-    let format_targets: &[&str] = match matches.value_of("format").unwrap() {
+    let format = matches.value_of("format").unwrap();
+    let format_targets: &[&str] = match format {
         "vsim" => &["vsim", "simulation"],
         "vcs" => &["vcs", "simulation"],
         "synopsys" => &["synopsys", "synthesis"],
@@ -120,17 +121,17 @@ pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
 
     // Validate format-specific options.
     if (matches.is_present("vcom-arg") || matches.is_present("vlog-arg"))
-            && matches.value_of("format") != Some("vsim") && matches.value_of("format") != Some("vcs") {
+            && format != "vsim" && format != "vcs" {
         return Err(Error::new("vsim/vcs-only options can only be used for 'vcs' or 'vsim' format!"));
     }
     if (matches.is_present("only-defines") || matches.is_present("only-includes")
                 || matches.is_present("only-sources") || matches.is_present("no-simset")
-            ) && matches.value_of("format") != Some("vivado") {
+            ) && format != "vivado" {
         return Err(Error::new("Vivado-only options can only be used for 'vivado' format!"));
     }
 
     // Generate the corresponding output.
-    match matches.value_of("format").unwrap() {
+    match format {
         "vsim" => emit_vsim_tcl(sess, matches, targets, srcs),
         "vcs" => emit_vcs_sh(sess, matches, targets, srcs),
         "synopsys" => emit_synopsys_tcl(sess, matches, targets, srcs),


### PR DESCRIPTION
Closes #23.

### Added
- Add `vivado-sim` format to the script command.  This format differs from the `vivado` format in that it targets simulation, not synthesis; other than that, it is equivalent to the `vivado` format.