### PR TITLE
script: Add `flist` target for plain file lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `flist` scripts target emitting a plain file list.
 
 ## 0.18.0 - 2020-04-03
 ### Added


### PR DESCRIPTION
This creates a plain file list. No defines, simple includes no file groups. At the moment we need this for the OpenPiton file list in Ariane (https://github.com/pulp-platform/ariane/pull/393).