### PR TITLE
cli: Also look for Bender.local recursively

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -264,11 +264,6 @@ fn load_config(from: &Path) -> Result<Config> {
     use std::os::unix::fs::MetadataExt;
     let mut out = PartialConfig::new();
 
-    // Load the optional local configuration.
-    if let Some(cfg) = maybe_load_config(&from.join("Bender.local"))? {
-        out = out.merge(cfg);
-    }
-
     // Canonicalize the path. This will resolve any intermediate links.
     let mut path = canonicalize(from)
         .map_err(|cause| Error::chain(format!("Failed to canonicalize path {:?}.", from), cause))?;
@@ -281,6 +276,11 @@ fn load_config(from: &Path) -> Result<Config> {
 
     // Step upwards through the path hierarchy.
     for _ in 0..100 {
+        // Load the optional local configuration.
+        if let Some(cfg) = maybe_load_config(&path.join("Bender.local"))? {
+            out = out.merge(cfg);
+        }
+
         debugln!("load_config: looking in {:?}", path);
 
         if let Some(cfg) = maybe_load_config(&path.join(".bender.yml"))? {


### PR DESCRIPTION
Bender would only check for a Bender.local in the root of the project
but fail to find any other `Bender.local`s on different hierarchy
levels. It now looks for `Bender.local` and `.bender.yml`.