### PR TITLE
Add command line argument for defines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add option to pass additional defines through the command line
 
 ## 0.20.0 - 2020-07-04
 ### Added

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -302,13 +302,13 @@ fn tcl_catch_postfix() -> &'static str {
     return "}]} {return 1}";
 }
 
-fn add_defines_from_matches(defines: &mut Vec<(String, Option<&str>)>, matches: &ArgMatches) {
+fn add_defines_from_matches(defines: &mut Vec<(String, Option<String>)>, matches: &ArgMatches) {
     if let Some(d) = matches.values_of("define") {
         defines.extend(
             d.map(|t| {
                 let mut parts = t.splitn(2, "=");
                 let name = parts.next().unwrap().trim(); // split always has at least one element
-                let value = parts.next().map(|v| v.trim());
+                let value = parts.next().map(|v| v.trim().to_string());
                 (name.to_string(), value)
             })
         );
@@ -343,8 +343,8 @@ fn emit_vsim_tcl(
                         if let Some(args) = matches.values_of("vlog-arg") {
                             lines.extend(args.map(Into::into));
                         }
-                        let mut defines: Vec<(String, Option<&str>)> = vec![];
-                        defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v)));
+                        let mut defines: Vec<(String, Option<String>)> = vec![];
+                        defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v.map(String::from))));
                         defines.extend(
                             targets
                                 .iter()
@@ -356,7 +356,7 @@ fn emit_vsim_tcl(
                             let mut s = format!("+define+{}", k.to_uppercase());
                             if let Some(v) = v {
                                 s.push('=');
-                                s.push_str(v);
+                                s.push_str(&v);
                             }
                             lines.push(s);
                         }
@@ -422,8 +422,8 @@ fn emit_vcs_sh(
                         if let Some(args) = matches.values_of("vlog-arg") {
                             lines.extend(args.map(Into::into));
                         }
-                        let mut defines: Vec<(String, Option<&str>)> = vec![];
-                        defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v)));
+                        let mut defines: Vec<(String, Option<String>)> = vec![];
+                        defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v.map(String::from))));
                         defines.extend(
                             targets
                                 .iter()
@@ -435,7 +435,7 @@ fn emit_vcs_sh(
                             let mut s = format!("+define+{}", k.to_uppercase());
                             if let Some(v) = v {
                                 s.push('=');
-                                s.push_str(v);
+                                s.push_str(&v);
                             }
                             lines.push(s);
                         }
@@ -491,8 +491,8 @@ fn emit_verilator_sh(
                         if let Some(args) = matches.values_of("vlog-arg") {
                             lines.extend(args.map(Into::into));
                         }
-                        let mut defines: Vec<(String, Option<&str>)> = vec![];
-                        defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v)));
+                        let mut defines: Vec<(String, Option<String>)> = vec![];
+                        defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v.map(String::from))));
                         defines.extend(
                             targets
                                 .iter()
@@ -504,7 +504,7 @@ fn emit_verilator_sh(
                             let mut s = format!("+define+{}", k.to_uppercase());
                             if let Some(v) = v {
                                 s.push('=');
-                                s.push_str(v);
+                                s.push_str(&v);
                             }
                             lines.push(s);
                         }
@@ -649,8 +649,8 @@ fn emit_synopsys_tcl(
                 );
 
                 // Add defines.
-                let mut defines: Vec<(String, Option<&str>)> = vec![];
-                defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v)));
+                let mut defines: Vec<(String, Option<String>)> = vec![];
+                defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v.map(String::from))));
                 defines.extend(
                     targets
                         .iter()
@@ -664,7 +664,7 @@ fn emit_synopsys_tcl(
                         let mut s = format!("    {}", k);
                         if let Some(v) = v {
                             s.push('=');
-                            s.push_str(v);
+                            s.push_str(&v);
                         }
                         lines.push(s);
                     }
@@ -751,8 +751,8 @@ fn emit_genus_tcl(
                 }
 
                 // Add defines.
-                let mut defines: Vec<(String, Option<&str>)> = vec![];
-                defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v)));
+                let mut defines: Vec<(String, Option<String>)> = vec![];
+                defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v.map(String::from))));
                 defines.extend(
                     targets
                         .iter()
@@ -766,7 +766,7 @@ fn emit_genus_tcl(
                         let mut s = format!("    {}", k);
                         if let Some(v) = v {
                             s.push('=');
-                            s.push_str(v);
+                            s.push_str(&v);
                         }
                         lines.push(s);
                     }
@@ -832,7 +832,7 @@ fn emit_vivado_tcl(
 
     println!("{}", header_tcl(sess));
     let mut include_dirs = vec![];
-    let mut defines = vec![];
+    let mut defines: Vec<(String, Option<String>)> = vec![];
     let filesets = if matches.is_present("no-simset") {
         vec![""]
     } else {
@@ -942,8 +942,8 @@ fn emit_riviera_tcl(
                             if let Some(args) = matches.values_of("vlog-arg") {
                                 lines.extend(args.map(Into::into));
                             }
-                            let mut defines: Vec<(String, Option<&str>)> = vec![];
-                            defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v)));
+                            let mut defines: Vec<(String, Option<String>)> = vec![];
+                            defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v.map(String::from))));
                             defines.extend(
                                 targets
                                     .iter()
@@ -955,7 +955,7 @@ fn emit_riviera_tcl(
                                 let mut s = format!("+define+{}", k.to_uppercase());
                                 if let Some(v) = v {
                                     s.push('=');
-                                    s.push_str(v);
+                                    s.push_str(&v);
                                 }
                                 lines.push(s);
                             }
@@ -993,7 +993,7 @@ fn emit_riviera_tcl(
         let mut file_lines = vec![];
         let mut inc_dirs = HashSet::new();
         let mut files = vec![];
-        let mut defines: Vec<(String, Option<&str>)> = vec![];
+        let mut defines: Vec<(String, Option<String>)> = vec![];
         let mut t: bool = false;
         for src in srcs {
             inc_dirs = src
@@ -1004,7 +1004,7 @@ fn emit_riviera_tcl(
                     acc
                 });
             files.append(&mut src.files.clone());
-            defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v)));
+            defines.extend(src.defines.iter().map(|(k, &v)| (k.to_string(), v.map(String::from))));
         }
         for file in files {
             let p = match file {
@@ -1038,7 +1038,7 @@ fn emit_riviera_tcl(
                 let mut s = format!("+define+{}", k.to_uppercase());
                 if let Some(v) = v {
                     s.push('=');
-                    s.push_str(v);
+                    s.push_str(&v);
                 }
                 lines.push(s);
             }

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -48,6 +48,13 @@ pub fn new<'a, 'b>() -> App<'a, 'b> {
                 .help("Use relative paths (flist generation only)"),
         )
         .arg(
+            Arg::with_name("defines")
+                .long("defines")
+                .help("Pass an additional define to all source files")
+                .takes_value(true)
+                .multiple(true),
+        )
+        .arg(
             Arg::with_name("vcom-arg")
                 .long("vcom-arg")
                 .help("Pass an argument to vcom calls (vsim/vhdlan/riviera only)")
@@ -864,6 +871,13 @@ fn emit_vivado_tcl(
             .iter()
             .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
     );
+    if let Some(define) = matches.values_of("defines") {
+        defines.extend(
+            matches.values_of("defines")
+            .unwrap()
+            .map(|t| (t.to_string(), None))
+        );
+    }
     if !defines.is_empty() && output_components.defines {
         defines.sort();
         defines.dedup();

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -48,8 +48,9 @@ pub fn new<'a, 'b>() -> App<'a, 'b> {
                 .help("Use relative paths (flist generation only)"),
         )
         .arg(
-            Arg::with_name("defines")
-                .long("defines")
+            Arg::with_name("define")
+                .short("D")
+                .long("define")
                 .help("Pass an additional define to all source files")
                 .takes_value(true)
                 .multiple(true),
@@ -871,9 +872,9 @@ fn emit_vivado_tcl(
             .iter()
             .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
     );
-    if let Some(define) = matches.values_of("defines") {
+    if let Some(d) = matches.values_of("define") {
         defines.extend(
-            matches.values_of("defines")
+            matches.values_of("define")
             .unwrap()
             .map(|t| (t.to_string(), None))
         );

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -874,9 +874,12 @@ fn emit_vivado_tcl(
     );
     if let Some(d) = matches.values_of("define") {
         defines.extend(
-            matches.values_of("define")
-            .unwrap()
-            .map(|t| (t.to_string(), None))
+            d.map(|t| {
+                let mut parts = t.splitn(2, "=");
+                let name = parts.next().unwrap().trim(); // split always has at least one element
+                let value = parts.next().map(|v| v.trim().to_string());
+                (name.to_string(), value)
+            })
         );
     }
     if !defines.is_empty() && output_components.defines {

--- a/src/cmd/script.rs
+++ b/src/cmd/script.rs
@@ -302,6 +302,19 @@ fn tcl_catch_postfix() -> &'static str {
     return "}]} {return 1}";
 }
 
+fn add_defines_from_matches(defines: &mut Vec<(String, Option<&str>)>, matches: &ArgMatches) {
+    if let Some(d) = matches.values_of("define") {
+        defines.extend(
+            d.map(|t| {
+                let mut parts = t.splitn(2, "=");
+                let name = parts.next().unwrap().trim(); // split always has at least one element
+                let value = parts.next().map(|v| v.trim());
+                (name.to_string(), value)
+            })
+        );
+    }
+}
+
 /// Emit a vsim compilation script.
 fn emit_vsim_tcl(
     sess: &Session,
@@ -337,6 +350,7 @@ fn emit_vsim_tcl(
                                 .iter()
                                 .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
                         );
+                        add_defines_from_matches(&mut defines, matches);
                         defines.sort();
                         for (k, v) in defines {
                             let mut s = format!("+define+{}", k.to_uppercase());
@@ -415,6 +429,7 @@ fn emit_vcs_sh(
                                 .iter()
                                 .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
                         );
+                        add_defines_from_matches(&mut defines, matches);
                         defines.sort();
                         for (k, v) in defines {
                             let mut s = format!("+define+{}", k.to_uppercase());
@@ -483,6 +498,7 @@ fn emit_verilator_sh(
                                 .iter()
                                 .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
                         );
+                        add_defines_from_matches(&mut defines, matches);
                         defines.sort();
                         for (k, v) in defines {
                             let mut s = format!("+define+{}", k.to_uppercase());
@@ -585,7 +601,7 @@ fn emit_flist(sess: &Session, matches: &ArgMatches, srcs: Vec<SourceGroup>) -> R
 /// Emit a Synopsys Design Compiler compilation script.
 fn emit_synopsys_tcl(
     sess: &Session,
-    _matches: &ArgMatches,
+    matches: &ArgMatches,
     targets: TargetSet,
     srcs: Vec<SourceGroup>,
     abort_on_error: bool,
@@ -640,6 +656,7 @@ fn emit_synopsys_tcl(
                         .iter()
                         .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
                 );
+                add_defines_from_matches(&mut defines, matches);
                 defines.sort();
                 if !defines.is_empty() {
                     lines.push("-define {".to_owned());
@@ -680,7 +697,7 @@ fn emit_synopsys_tcl(
 /// Emit a Cadence Genus compilation script.
 fn emit_genus_tcl(
     sess: &Session,
-    _matches: &ArgMatches,
+    matches: &ArgMatches,
     targets: TargetSet,
     srcs: Vec<SourceGroup>,
 ) -> Result<()> {
@@ -741,6 +758,7 @@ fn emit_genus_tcl(
                         .iter()
                         .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
                 );
+                add_defines_from_matches(&mut defines, matches);
                 defines.sort();
                 if !defines.is_empty() {
                     lines.push("-define {".to_owned());
@@ -872,16 +890,7 @@ fn emit_vivado_tcl(
             .iter()
             .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
     );
-    if let Some(d) = matches.values_of("define") {
-        defines.extend(
-            d.map(|t| {
-                let mut parts = t.splitn(2, "=");
-                let name = parts.next().unwrap().trim(); // split always has at least one element
-                let value = parts.next().map(|v| v.trim().to_string());
-                (name.to_string(), value)
-            })
-        );
-    }
+    add_defines_from_matches(&mut defines, matches);
     if !defines.is_empty() && output_components.defines {
         defines.sort();
         defines.dedup();
@@ -940,6 +949,7 @@ fn emit_riviera_tcl(
                                     .iter()
                                     .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
                             );
+                            add_defines_from_matches(&mut defines, matches);
                             defines.sort();
                             for (k, v) in defines {
                                 let mut s = format!("+define+{}", k.to_uppercase());
@@ -1022,6 +1032,7 @@ fn emit_riviera_tcl(
                     .iter()
                     .map(|t| (format!("TARGET_{}", t.to_uppercase()), None)),
             );
+            add_defines_from_matches(&mut defines, matches);
             defines.sort();
             for (k, v) in defines {
                 let mut s = format!("+define+{}", k.to_uppercase());


### PR DESCRIPTION
Add a flag (`--defines`) which allows giving additional defines through the command line