### PR TITLE
Extend Bender availability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+env:
+  - PKG_OS="centos:7.4.1708 centos:7.6.1810 centos:7.7.1908 centos:7.8.2003"
 
 services:
   - docker
 
 before_install:
-  - for centos in '7.4.1708' '7.6.1810' '7.7.1908' '7.8.2003'; do
-      .ci/if_deploy_build.sh docker pull accuminium/rust-centos:${centos}_${TRAVIS_RUST_VERSION};
+  - for os in $PKG_OS; do
+      .ci/if_deploy_build.sh docker pull accuminium/rust-${os}_${TRAVIS_RUST_VERSION};
     done
 
 before_script:
@@ -28,19 +30,21 @@ script:
 
 after_success:
   - .ci/if_deploy_build.sh cargo build --release
-  - for centos in '7.4.1708' '7.6.1810' '7.7.1908' '7.8.2003'; do
+  - for os in $PKG_OS; do
+      tgtname=$(echo $os | tr -d ':')
       .ci/if_deploy_build.sh docker run
         -t --rm
         -v "$PWD:/source"
-        -v "$PWD/target/centos$centos:/source/target"
-        accuminium/rust-centos:${centos}_${TRAVIS_RUST_VERSION}
+        -v "$PWD/target/$tgtname:/source/target"
+        accuminium/rust-${os}_${TRAVIS_RUST_VERSION}
         cargo build --release;
     done
 
 before_deploy:
   - .ci/if_deploy_build.sh .ci/package.sh
-  - for centos in '7.4.1708' '7.6.1810' '7.7.1908' '7.8.2003'; do
-      .ci/if_deploy_build.sh .ci/package.sh centos$centos;
+  - for os in $PKG_OS; do
+      tgtname=$(echo $os | tr -d ':')
+      .ci/if_deploy_build.sh .ci/package.sh $tgtname;
     done
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   allow_failures:
     - rust: nightly
 env:
-  - PKG_OS="centos:7.4.1708 centos:7.6.1810 centos:7.7.1908 centos:7.8.2003"
+  - PKG_OS="centos:7.4.1708 centos:7.6.1810 centos:7.7.1908 centos:7.8.2003 ubuntu:16.04 ubuntu:18.04 ubuntu:20.04 ubuntu:20.10"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   allow_failures:
     - rust: nightly
 env:
-  - PKG_OS="centos:7.4.1708 centos:7.6.1810 centos:7.7.1908 centos:7.8.2003 ubuntu:16.04 ubuntu:18.04 ubuntu:20.04 ubuntu:20.10"
+  - PKG_OS="centos:7.4.1708 centos:7.6.1810 centos:7.7.1908 centos:7.8.2003 centos:8.1.1911 centos:8.2.2004 ubuntu:16.04 ubuntu:18.04 ubuntu:20.04 ubuntu:20.10"
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ Bender is a dependency management tool for hardware design projects. It provides
 ![Crates.io](https://img.shields.io/crates/l/bender)
 
 
+## Table of Contents
+
+- [Principles](#principles)
+- [Workflow](#workflow)
+- [Package Structure](#package-structure)
+- [Manifest Format (`Bender.yml`)](#manifest-format-benderyml)
+  - [Dependencies](#dependencies)
+  - [Sources](#sources)
+  - [Targets](#targets)
+- [Configuration Format (`bender.yml`, `Bender.local`)](#configuration-format-benderyml-benderlocal)
+- [Commands](#commands)
+
+
 ## Principles
 
 Bender is built around the following core principles:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Bender is a dependency management tool for hardware design projects. It provides
 ## Table of Contents
 
 - [Principles](#principles)
+- [Installation](#installation)
 - [Workflow](#workflow)
 - [Package Structure](#package-structure)
 - [Manifest Format (`Bender.yml`)](#manifest-format-benderyml)
@@ -41,6 +42,26 @@ Bender is built around the following core principles:
   - Enforce strict use of [semantic versioning](https://semver.org/)
 
 - **Generate tool scripts.** The third feature tier of Bender is the ability to generate source file listings and compilation scripts for various tools.
+
+
+## Installation
+
+To use Bender for a single project, the simplest is to download and use a precompiled binary.  We provide binaries for all current versions of Ubuntu and CentOS, as well as generic Linux, on each release.  Open a terminal and enter the following command:
+```sh
+curl --proto '=https' --tlsv1.2 https://fabianschuiki.github.io/bender/init -sSf | sh
+```
+The command downloads and executes a script that detects your distribution and downloads the appropriate `bender` binary of the latest release to your current directory.  If you need a specific version of Bender (e.g., `0.21.0`), append ` -s -- 0.21.0` to that command.  Alternatively, you can manually download a precompiled binary from [our Releases on GitHub][releases].
+
+If you prefer building your own binary, you need to [install Rust][rust-installation].  You can then build and install Bender for the current user with the following command:
+```sh
+cargo install bender
+```
+If you need a specific version of Bender (e.g., `0.21.0`), append ` --version 0.21.0` to that command.
+
+To install Bender system-wide, you can simply copy the binary you have obtained from one of the above methods to one of the system directories on your `PATH`.  Even better, some Linux distributions have Bender in their repositories.  We are currently aware of:
+- ArchLinux: [Bender (AUR)][aur-bender]
+
+Please extend this list through a PR if you know additional distributions.
 
 
 ## Workflow
@@ -374,3 +395,8 @@ Supported formats:
 Whenever you update the list of dependencies, you likely have to run `bender update` to re-resolve the dependency versions, and recreate the `Bender.lock` file.
 
 > Note: Actually this should be done automatically if you add a new dependency. But due to the lack of coding time, this has to be done manually as of now.
+
+
+[aur-bender]: https://aur.archlinux.org/packages/bender
+[releases]: https://github.com/fabianschuiki/bender/releases
+[rust-installation]: https://doc.rust-lang.org/book/ch01-01-installation.html


### PR DESCRIPTION
- Add table of contents to ReadMe.
- Add an *Installation* section, which describes three alternative methods to obtain Bender, to the ReadMe.
- Extend automatic builds to Ubuntu and more versions of CentOS.

For the first installation method to work, GitHub pages on this repository needs to be activated on the `website` branch.