### PR TITLE
Added `clone` and `parents` command for improved workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 ### Added
-- `workon` command to checkout individual ips to a directory and create a path reference in Bender.local
+- `clone` command to checkout individual ips to a directory and create a path reference in Bender.local
 - `parents` command to get list of packages requiring the queried package
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 ### Added
 - `workon` command to checkout individual ips to a directory and create a path reference in Bender.local
+- `parents` command to get list of packages requiring the queried package
 
 ### Fixed
 - plugins work for scripts in root repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `workon` command to checkout individual ips to a directory and create a path reference in Bender.local
+
+### Fixed
+- plugins work for scripts in root repository
+- force git fetch on unsatisfied requirements to check for newly added tags in server repository
 
 ## 0.21.0 - 2020-11-04
 ### Added

--- a/README.md
+++ b/README.md
@@ -397,9 +397,9 @@ Whenever you update the list of dependencies, you likely have to run `bender upd
 > Note: Actually this should be done automatically if you add a new dependency. But due to the lack of coding time, this has to be done manually as of now.
 
 
-### `workon` --- Checkout dependency to make modifications
+### `clone` --- Checkout dependency to make modifications
 
-The `bender workon <PKG>` command checks out the package `PKG` into a directory (default `working_dir`, can be overridden with `-p / --path <DIR>`). 
+The `bender clone <PKG>` command checks out the package `PKG` into a directory (default `working_dir`, can be overridden with `-p / --path <DIR>`). 
 To ensure the package is correctly linked in bender, the `Bender.local` file is modified to include a `path` dependency override, linking to the corresponding package.
 
 This can be used for development of dependent packages alowing with the larger repo, allowing to test uncommitted and committed changes, without the worry that bender would update the dependency.

--- a/README.md
+++ b/README.md
@@ -399,12 +399,16 @@ Whenever you update the list of dependencies, you likely have to run `bender upd
 
 ### `workon` --- Checkout dependency to make modifications
 
-The `bender workon <PKG>` checks out the package `PKG` into a directory (default `working_dir`, can be overridden with `-p / --path <DIR>`). 
+The `bender workon <PKG>` command checks out the package `PKG` into a directory (default `working_dir`, can be overridden with `-p / --path <DIR>`). 
 To ensure the package is correctly linked in bender, the `Bender.local` file is modified to include a `path` dependency override, linking to the corresponding package.
 
 This can be used for development of dependent packages alowing with the larger repo, allowing to test uncommitted and committed changes, without the worry that bender would update the dependency.
 
 To clean up once the changes are added, ensure the correct version is referenced by the calling packages and remove the path dependency in Bender.local.
+
+### `parents` --- Lists packages calling the specified package
+
+The `bender parents <PKG>` command lists all packages calling the `PKG` package.
 
 [aur-bender]: https://aur.archlinux.org/packages/bender
 [releases]: https://github.com/fabianschuiki/bender/releases

--- a/README.md
+++ b/README.md
@@ -397,6 +397,15 @@ Whenever you update the list of dependencies, you likely have to run `bender upd
 > Note: Actually this should be done automatically if you add a new dependency. But due to the lack of coding time, this has to be done manually as of now.
 
 
+### `workon` --- Checkout dependency to make modifications
+
+The `bender workon <PKG>` checks out the package `PKG` into a directory (default `working_dir`, can be overridden with `-p / --path <DIR>`). 
+To ensure the package is correctly linked in bender, the `Bender.local` file is modified to include a `path` dependency override, linking to the corresponding package.
+
+This can be used for development of dependent packages alowing with the larger repo, allowing to test uncommitted and committed changes, without the worry that bender would update the dependency.
+
+To clean up once the changes are added, ensure the correct version is referenced by the calling packages and remove the path dependency in Bender.local.
+
 [aur-bender]: https://aur.archlinux.org/packages/bender
 [releases]: https://github.com/fabianschuiki/bender/releases
 [rust-installation]: https://doc.rust-lang.org/book/ch01-01-installation.html

--- a/README.md
+++ b/README.md
@@ -402,9 +402,11 @@ Whenever you update the list of dependencies, you likely have to run `bender upd
 The `bender clone <PKG>` command checks out the package `PKG` into a directory (default `working_dir`, can be overridden with `-p / --path <DIR>`). 
 To ensure the package is correctly linked in bender, the `Bender.local` file is modified to include a `path` dependency override, linking to the corresponding package.
 
-This can be used for development of dependent packages alowing with the larger repo, allowing to test uncommitted and committed changes, without the worry that bender would update the dependency.
+This can be used for development of dependent packages within the parent repository, allowing to test uncommitted and committed changes, without the worry that bender would update the dependency.
 
 To clean up once the changes are added, ensure the correct version is referenced by the calling packages and remove the path dependency in Bender.local.
+
+> Note: The location of the override may be updated in the future to prevent modifying the human-editable `Bender.local` file.
 
 ### `parents` --- Lists packages calling the specified package
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,7 @@ pub fn main() -> Result<()> {
         )
         .subcommand(SubCommand::with_name("update").about("Update the dependencies"))
         .subcommand(cmd::path::new())
+        .subcommand(cmd::parents::new())
         .subcommand(cmd::workon::new())
         .subcommand(cmd::packages::new())
         .subcommand(cmd::sources::new())
@@ -187,6 +188,7 @@ pub fn main() -> Result<()> {
     // Dispatch the different subcommands.
     match matches.subcommand() {
         ("path", Some(matches)) => cmd::path::run(&sess, matches),
+        ("parents", Some(matches)) => cmd::parents::run(&sess, matches),
         ("workon", Some(matches)) => cmd::workon::run(&sess, &root_dir, matches),
         ("packages", Some(matches)) => cmd::packages::run(&sess, matches),
         ("sources", Some(matches)) => cmd::sources::run(&sess, matches),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,7 @@ pub fn main() -> Result<()> {
         )
         .subcommand(SubCommand::with_name("update").about("Update the dependencies"))
         .subcommand(cmd::path::new())
+        .subcommand(cmd::workon::new())
         .subcommand(cmd::packages::new())
         .subcommand(cmd::sources::new())
         .subcommand(cmd::config::new())
@@ -186,6 +187,7 @@ pub fn main() -> Result<()> {
     // Dispatch the different subcommands.
     match matches.subcommand() {
         ("path", Some(matches)) => cmd::path::run(&sess, matches),
+        ("workon", Some(matches)) => cmd::workon::run(&sess, &root_dir, matches),
         ("packages", Some(matches)) => cmd::packages::run(&sess, matches),
         ("sources", Some(matches)) => cmd::sources::run(&sess, matches),
         ("config", Some(matches)) => cmd::config::run(&sess, matches),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ pub fn main() -> Result<()> {
         .subcommand(SubCommand::with_name("update").about("Update the dependencies"))
         .subcommand(cmd::path::new())
         .subcommand(cmd::parents::new())
-        .subcommand(cmd::workon::new())
+        .subcommand(cmd::clone::new())
         .subcommand(cmd::packages::new())
         .subcommand(cmd::sources::new())
         .subcommand(cmd::config::new())
@@ -189,7 +189,7 @@ pub fn main() -> Result<()> {
     match matches.subcommand() {
         ("path", Some(matches)) => cmd::path::run(&sess, matches),
         ("parents", Some(matches)) => cmd::parents::run(&sess, matches),
-        ("workon", Some(matches)) => cmd::workon::run(&sess, &root_dir, matches),
+        ("clone", Some(matches)) => cmd::clone::run(&sess, &root_dir, matches),
         ("packages", Some(matches)) => cmd::packages::run(&sess, matches),
         ("sources", Some(matches)) => cmd::sources::run(&sess, matches),
         ("config", Some(matches)) => cmd::config::run(&sess, matches),

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -16,17 +16,17 @@ use crate::sess::{Session, SessionIo};
 /// Assemble the `clone` subcommand.
 pub fn new<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("clone")
-        .about("Checkout dependency to a working directory")
+        .about("Clone dependency to a working directory")
         .arg(
             Arg::with_name("name")
                 .required(true)
-                .help("Package name to checkout to working_dir"),
+                .help("Package name to clone to a working directory"),
         )
         .arg(
             Arg::with_name("path")
                 .short("p")
                 .long("path")
-                .help("working_dir override")
+                .help("Relative directory to clone PKG into (default: working_dir)")
                 .takes_value(true)
                 .number_of_values(1),
         )

--- a/src/cmd/clone.rs
+++ b/src/cmd/clone.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 ETH Zurich
 // Michael Rogenmoser <michaero@student.ethz.ch>
 
-//! The `workon` subcommand.
+//! The `clone` subcommand.
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 use futures::future;
@@ -13,9 +13,9 @@ use crate::config;
 use crate::error::*;
 use crate::sess::{Session, SessionIo};
 
-/// Assemble the `workon` subcommand.
+/// Assemble the `clone` subcommand.
 pub fn new<'a, 'b>() -> App<'a, 'b> {
-    SubCommand::with_name("workon")
+    SubCommand::with_name("clone")
         .about("Checkout dependency to a working directory")
         .arg(
             Arg::with_name("name")
@@ -32,7 +32,7 @@ pub fn new<'a, 'b>() -> App<'a, 'b> {
         )
 }
 
-/// Execute the `workon` subcommand.
+/// Execute the `clone` subcommand.
 pub fn run(sess: &Session, path: &Path, matches: &ArgMatches) -> Result<()> {
     let dep = matches.value_of("name").unwrap();
     sess.dependency_with_name(dep)?;
@@ -155,7 +155,7 @@ pub fn run(sess: &Session, path: &Path, matches: &ArgMatches) -> Result<()> {
     // Rewrite Bender.local file to keep changes
     let local_path = path.join("Bender.local");
     let dep_str = format!(
-        "  {}: {{ path: \"{}/{0}\" }} # Temporary override by Bender using `workon` command\n",
+        "  {}: {{ path: \"{}/{0}\" }} # Temporary override by Bender using `bender clone` command\n",
         dep, path_mod
     );
     if local_path.exists() {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -12,3 +12,4 @@ pub mod packages;
 pub mod path;
 pub mod script;
 pub mod sources;
+pub mod workon;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod config;
 pub mod packages;
+pub mod parents;
 pub mod path;
 pub mod script;
 pub mod sources;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -7,10 +7,10 @@
 
 #![deny(missing_docs)]
 
+pub mod clone;
 pub mod config;
 pub mod packages;
 pub mod parents;
 pub mod path;
 pub mod script;
 pub mod sources;
-pub mod workon;

--- a/src/cmd/parents.rs
+++ b/src/cmd/parents.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 ETH Zurich
+// Michael Rogenmoser <michaero@student.ethz.ch>
+
+//! The `parents` subcommand.
+
+use clap::{App, Arg, ArgMatches, SubCommand};
+use std::collections::HashMap;
+
+use crate::error::*;
+use crate::sess::Session;
+
+/// Assemble the `parents` subcommand.
+pub fn new<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("parents")
+        .about("List packages calling this dependency")
+        .arg(
+            Arg::with_name("name")
+                .required(true)
+                .help("Package names to get the parents for"),
+        )
+}
+
+/// Execute the `parents` subcommand.
+pub fn run(sess: &Session, matches: &ArgMatches) -> Result<()> {
+    let dep = matches.value_of("name").unwrap();
+    sess.dependency_with_name(dep)?;
+
+    let parent_array = {
+        let mut map = HashMap::<&str, &str>::new();
+        if sess.manifest.dependencies.contains_key(dep) {
+            map.insert(&sess.manifest.package.name, "version tbd");
+        }
+        for (&pkg, deps) in sess.graph().iter() {
+            let pkg_name = sess.dependency_name(pkg);
+            let dep_names = deps.iter().map(|&id| sess.dependency_name(id));
+            for dep_name in dep_names {
+                if dep == dep_name {
+                    map.insert(pkg_name, "version tbd"); // TODO find each version reference
+                }
+            }
+        }
+        map
+    };
+
+    if parent_array.len() == 0 {
+        println!("No parents found for {}.", dep);
+    } else {
+        println!("Parents found:");
+        for (k, _v) in parent_array.iter() {
+            println!("    {}", k);
+        }
+    }
+
+    Ok(())
+}

--- a/src/cmd/workon.rs
+++ b/src/cmd/workon.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2021 ETH Zurich
+// Michael Rogenmoser <michaero@student.ethz.ch>
+
+//! The `workon` subcommand.
+
+use clap::{App, Arg, ArgMatches, SubCommand};
+use futures::future;
+use std::path::Path;
+use std::process::Command;
+use tokio_core::reactor::Core;
+
+use crate::config;
+use crate::error::*;
+use crate::sess::{Session, SessionIo};
+
+/// Assemble the `workon` subcommand.
+pub fn new<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("workon")
+        .about("Checkout dependency to a working directory")
+        .arg(
+            Arg::with_name("name")
+                .required(true)
+                .help("Package name to checkout to working_dir"),
+        )
+        .arg(
+            Arg::with_name("path")
+                .short("p")
+                .long("path")
+                .help("working_dir override")
+                .takes_value(true)
+                .number_of_values(1),
+        )
+}
+
+/// Execute the `workon` subcommand.
+pub fn run(sess: &Session, path: &Path, matches: &ArgMatches) -> Result<()> {
+    let dep = matches.value_of("name").unwrap();
+    sess.dependency_with_name(dep)?;
+
+    let path_mod = matches.value_of("path").unwrap_or_else(|| "working_dir"); // TODO make this option for config in the Bender.yml file?
+
+    // Check current config for matches
+    if sess.config.overrides.contains_key(dep) {
+        match &sess.config.overrides[dep] {
+            config::Dependency::Path(p) => {
+                Err(Error::new(format!(
+                    "Dependency `{}` already has a path override at\n\t{}\n\tPlease check Bender.local or .bender.yml",
+                    dep,
+                    p.to_str().unwrap()
+                )))?;
+            }
+            _ => {
+                println!("A non-path override is already present, proceeding anyways");
+            }
+        }
+    }
+
+    // Create dir
+    if !path.join(path_mod).exists() {
+        if !Command::new("mkdir")
+            .arg(path_mod)
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+        {
+            Err(Error::new(format!("Creating dir {} failed", path_mod,)))?;
+        }
+    }
+
+    // Copy dependency to dir for proper workflow
+    if path.join(path_mod).join(dep).exists() {
+        println!("{} already has a directory in {}.", dep, path_mod);
+        println!("Please manually ensure the correct checkout.");
+    } else {
+        let mut core = Core::new().unwrap();
+        let io = SessionIo::new(&sess, core.handle());
+
+        let ids = matches
+            .values_of("name")
+            .unwrap()
+            .map(|n| Ok((n, sess.dependency_with_name(n)?)))
+            .collect::<Result<Vec<_>>>()?;
+        debugln!("main: obtain checkouts {:?}", ids);
+        let checkouts = core.run(future::join_all(
+            ids.iter()
+                .map(|&(_, id)| io.checkout(id))
+                .collect::<Vec<_>>(),
+        ))?;
+        debugln!("main: checkouts {:#?}", checkouts);
+        for c in checkouts {
+            if let Some(s) = c.to_str() {
+                let command = Command::new("cp")
+                    .arg("-rf")
+                    .arg(s)
+                    .arg(path.join(path_mod).join(dep).to_str().unwrap())
+                    .status();
+                if !command.unwrap().success() {
+                    Err(Error::new(format!("Copying {} failed", dep,)))?;
+                }
+                // println!("{:?}", command);
+            }
+        }
+
+        // rename and update git remotes for easier handling
+        if !Command::new(&sess.config.git)
+            .arg("remote")
+            .arg("rename")
+            .arg("origin")
+            .arg("source")
+            .current_dir(path.join(path_mod).join(dep))
+            .status()
+            .unwrap()
+            .success()
+        {
+            Err(Error::new(format!("git renaming remote origin failed")))?;
+        }
+
+        if !Command::new(&sess.config.git)
+            .arg("remote")
+            .arg("add")
+            .arg("origin")
+            .arg(
+                &sess
+                    .dependency(sess.dependency_with_name(dep)?)
+                    .source
+                    .to_str(),
+            )
+            .current_dir(path.join(path_mod).join(dep))
+            .status()
+            .unwrap()
+            .success()
+        {
+            Err(Error::new(format!("git adding remote failed")))?;
+        }
+
+        if !Command::new(&sess.config.git)
+            .arg("fetch")
+            .arg("--all")
+            .current_dir(path.join(path_mod).join(dep))
+            .status()
+            .unwrap()
+            .success()
+        {
+            Err(Error::new(format!("git fetch failed")))?;
+        }
+
+        println!(
+            "{} checkout added in {:?}",
+            dep,
+            path.join(path_mod).join(dep)
+        );
+    }
+
+    // Rewrite Bender.local file to keep changes
+    let local_path = path.join("Bender.local");
+    let dep_str = format!(
+        "  {}: {{ path: \"{}/{0}\" }} # Temporary override by Bender using `workon` command\n",
+        dep, path_mod
+    );
+    if local_path.exists() {
+        let local_file_str = match std::fs::read_to_string(&local_path) {
+            Err(why) => Err(Error::new(format!(
+                "Reading Bender.local failed with msg:\n\t{}",
+                why
+            )))?,
+            Ok(local_file_str) => local_file_str,
+        };
+        let mut new_str = String::new();
+        if local_file_str.contains("overrides:") {
+            let split = local_file_str.split("\n");
+            let test = split.clone().last().unwrap().is_empty();
+            for i in split {
+                if i.contains(dep) {
+                    new_str.push('#');
+                }
+                new_str.push_str(i);
+                new_str.push_str("\n");
+                if i.contains("overrides:") {
+                    new_str.push_str(&dep_str);
+                }
+            }
+            if test {
+                // Ensure trailing newline is not duplicated
+                new_str.pop();
+            }
+        } else {
+            new_str.push_str(&format!("overrides:\n{}", dep_str));
+            new_str.push_str(&local_file_str);
+        }
+        match std::fs::write(local_path, new_str) {
+            Err(why) => Err(Error::new(format!(
+                "Writing new Bender.local failed with msg:\n\t{}",
+                why
+            )))?,
+            Ok(_) => (),
+        }
+    } else {
+        match std::fs::write(local_path, format!("overrides:\n{}", dep_str)) {
+            Err(why) => Err(Error::new(format!(
+                "Writing new Bender.local failed with msg:\n\t{}",
+                why
+            )))?,
+            Ok(_) => (),
+        };
+    }
+
+    println!("{} dependency added to Bender.local", dep);
+
+    Ok(())
+}

--- a/src/sess.rs
+++ b/src/sess.rs
@@ -1201,6 +1201,17 @@ impl fmt::Display for DependencySource {
     }
 }
 
+impl DependencySource {
+    /// returns a string of the source
+    pub fn to_str(&self) -> String {
+        match *self {
+            DependencySource::Registry => "registry".to_string(),
+            DependencySource::Path(ref path) => format!("{:?}", path),
+            DependencySource::Git(ref url) => format!("{}", url),
+        }
+    }
+}
+
 /// A table of internalized dependencies.
 #[derive(Debug)]
 struct DependencyTable<'ctx> {
@@ -1281,6 +1292,17 @@ impl<'ctx> fmt::Display for DependencyVersion<'ctx> {
             DependencyVersion::Path => write!(f, "path"),
             DependencyVersion::Registry(ref v) => write!(f, "{}", v),
             DependencyVersion::Git(ref r) => write!(f, "{}", r),
+        }
+    }
+}
+
+impl<'ctx> DependencyVersion<'ctx> {
+    /// returns a string of the version
+    pub fn to_str(&self) -> String {
+        match *self {
+            DependencyVersion::Path => "path".to_string(),
+            DependencyVersion::Registry(ref v) => format!("{}", v),
+            DependencyVersion::Git(ref r) => format!("{}", r),
         }
     }
 }


### PR DESCRIPTION
Added `clone` command to copy a git dependency to a workable location, adding a path override to Bender.local.
Added `parents` command to list packages calling a specified package.