### PR TITLE
Fix tests on recent Git versions

### DIFF
--- a/tests/iss2_empty_dep_test.sh
+++ b/tests/iss2_empty_dep_test.sh
@@ -20,7 +20,7 @@ package:
   name: bar
 
 dependencies:
-  foo: { git: \"file://$DIR/foo\", rev: master }
+  foo: { git: \"file://$DIR/foo\", rev: main }
 " > Bender.yml
 if $BENDER path foo &> log; then # this fails according to issue #2
 	cat log
@@ -28,7 +28,7 @@ if $BENDER path foo &> log; then # this fails according to issue #2
 	exit 1
 fi
 
-if ! grep -E 'Dependency `foo` from `.*?` cannot satisfy requirement `master`' log; then
+if ! grep -E 'Dependency `foo` from `.*?` cannot satisfy requirement `main`' log; then
 	cat log
 	echo "should fail differently" >&2
 	exit 2

--- a/tests/iss5_checkout_branch_test.sh
+++ b/tests/iss5_checkout_branch_test.sh
@@ -19,7 +19,7 @@ touch README
 git add .
 git commit -m "Hello"
 
-readonly BRANCH=$(git branch --show-current)
+readonly BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 cd "$DIR"/bar
 echo "

--- a/tests/iss5_checkout_branch_test.sh
+++ b/tests/iss5_checkout_branch_test.sh
@@ -19,12 +19,14 @@ touch README
 git add .
 git commit -m "Hello"
 
+readonly BRANCH=$(git branch --show-current)
+
 cd "$DIR"/bar
 echo "
 package:
   name: bar
 
 dependencies:
-  foo: { git: \"file://$DIR/foo\", rev: master }
+  foo: { git: \"file://$DIR/foo\", rev: $BRANCH }
 " > Bender.yml
 $BENDER path foo # this fails according to issue #5


### PR DESCRIPTION
Recent versions of Git default to `main` as default branch name.  This causes the `iss5` test to fail.  This PR fixes this in a backwards-compatible way.

Additionally, `rev` in the `iss2` test is updated to use `main` as default branch name.